### PR TITLE
Fixed resume from checkpoint

### DIFF
--- a/classy/scripts/model/train.py
+++ b/classy/scripts/model/train.py
@@ -115,7 +115,7 @@ def train(conf: DictConfig) -> None:
         conf.training.pl_trainer,
         callbacks=callbacks_store,
         logger=logger,
-        resume_from_checkpoint=resume_from_checkpoint
+        resume_from_checkpoint=resume_from_checkpoint,
     )
 
     # save resources

--- a/classy/scripts/model/train.py
+++ b/classy/scripts/model/train.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from typing import Optional, Union
 
 import hydra
 import pytorch_lightning as pl
@@ -106,18 +107,16 @@ def train(conf: DictConfig) -> None:
         callbacks_store.append(learning_rate_monitor)
 
     # trainer
+    resume_from_checkpoint: Optional[Union[Path, str]] = None
     if conf.training.resume_from is not None:
-        trainer = pl.trainer.Trainer(
-            resume_from_checkpoint=conf.training.resume_from,
-            callbacks=callbacks_store,
-            logger=logger,
-        )
-    else:
-        trainer: pl.trainer.Trainer = hydra.utils.instantiate(
-            conf.training.pl_trainer,
-            callbacks=callbacks_store,
-            logger=logger,
-        )
+        resume_from_checkpoint = conf.training.resume_from
+
+    trainer: pl.trainer.Trainer = hydra.utils.instantiate(
+        conf.training.pl_trainer,
+        callbacks=callbacks_store,
+        logger=logger,
+        resume_from_checkpoint=resume_from_checkpoint
+    )
 
     # save resources
     pl_module.save_resources_and_update_config(

--- a/classy/scripts/model/train.py
+++ b/classy/scripts/model/train.py
@@ -107,15 +107,10 @@ def train(conf: DictConfig) -> None:
         callbacks_store.append(learning_rate_monitor)
 
     # trainer
-    resume_from_checkpoint: Optional[Union[Path, str]] = None
-    if conf.training.resume_from is not None:
-        resume_from_checkpoint = conf.training.resume_from
-
     trainer: pl.trainer.Trainer = hydra.utils.instantiate(
         conf.training.pl_trainer,
         callbacks=callbacks_store,
         logger=logger,
-        resume_from_checkpoint=resume_from_checkpoint,
     )
 
     # save resources
@@ -127,4 +122,4 @@ def train(conf: DictConfig) -> None:
     )
 
     # module fit
-    trainer.fit(pl_module, datamodule=pl_data_module)
+    trainer.fit(pl_module, datamodule=pl_data_module, ckpt_path=conf.training.resume_from)


### PR DESCRIPTION
Fixes the [bug](https://github.com/sunglasses-ai/classy/issues/83):
The trainer parameters were not loaded correctly when the model was loaded from a checkpoint. E.g. val_check_interval was not set, so validation callbacks were not called rightly.